### PR TITLE
Should fix buffer overrun warnings in hstinpt from compiler.

### DIFF
--- a/src/phastinput/hstinpt.h
+++ b/src/phastinput/hstinpt.h
@@ -770,7 +770,7 @@ chemistry_name, *
 	database_name;
 
 EXTERNAL char
-	error_string[10 * MAX_LENGTH];
+	error_string[11 * MAX_LENGTH];
 EXTERNAL char
 	tag[10 * MAX_LENGTH];
 EXTERNAL int


### PR DESCRIPTION
I just made the target string, error_string, 256 characters bigger than the tag string that was being written to it.